### PR TITLE
Use `phi` and `phiB` to compute tp local variables

### DIFF
--- a/efficiencies/run_config.yaml
+++ b/efficiencies/run_config.yaml
@@ -79,10 +79,22 @@ particle_types:
         branch: 'ph2TpgPhiEmuAm_sector'
       st: 
         branch: 'ph2TpgPhiEmuAm_station'
+      sl:
+        branch: 'ph2TpgPhiEmuAm_superLayer'
       phi: 
         branch: 'ph2TpgPhiEmuAm_phi'
+      phires_conv:
+        expr: '65536.0 / 0.5'
       phiB: 
         branch: 'ph2TpgPhiEmuAm_phiB'
+      phiBres_conv: 
+        expr: '4096.0 / 2.0'
+      posLoc_x:
+        src: 'utils.tps_functions.compute_x0'
+        kwargs:
+          ref_frame: "SL13Center"
+      dirLoc_phi:
+        src: 'utils.tps_functions.compute_psi_local'
       quality: 
         branch: 'ph2TpgPhiEmuAm_quality'
       rpcFlag: 
@@ -91,8 +103,6 @@ particle_types:
         branch: 'ph2TpgPhiEmuAm_BX'
       BX: # then re-define the BX attribute to center it at 0
         expr: '_BX - 20'
-      phires_conv:
-        expr: '65536.0 / 0.5'
       matched_segments: []
       matched_genmuons: []
     filter: 'p.quality >= 0'
@@ -139,6 +149,7 @@ particle_types:
         branch: 'ph2Shower_avg_time'
       wires_profile: 
         branch: 'ph2Shower_wires_profile'
+    filter: 'p.sl !=2' # only consider showers in SL1 and SL3 at the moment
   simhits:
     amount: 'simHit_nSimHits'
     attributes:

--- a/filter_studies/run_config.yaml
+++ b/filter_studies/run_config.yaml
@@ -59,12 +59,18 @@ particle_types:
         branch: 'ph2TpgPhiEmuAm_superLayer'
       phi: 
         branch: 'ph2TpgPhiEmuAm_phi'
+      phires_conv:
+        expr: '65536.0 / 0.5'
       phiB: 
         branch: 'ph2TpgPhiEmuAm_phiB'
+      phiBres_conv: 
+        expr: '4096.0 / 2.0'
       posLoc_x:
-        branch: 'ph2TpgPhiEmuAm_posLoc_x'
+        src: 'utils.tps_functions.compute_x0'
+        kwargs:
+          ref_frame: "SL13Center"
       dirLoc_phi:
-        branch: 'ph2TpgPhiEmuAm_dirLoc_phi'
+        src: 'utils.tps_functions.compute_psi_local'
       quality: 
         branch: 'ph2TpgPhiEmuAm_quality'
       rpcFlag: 
@@ -73,8 +79,6 @@ particle_types:
         branch: 'ph2TpgPhiEmuAm_BX'
       BX: # then re-define the BX attribute to center it at 0
         expr: '_BX - 20'
-      phires_conv:
-        expr: '65536.0 / 0.5'
       matched_segments: []
       matched_genmuons: []
       matched_showers: []
@@ -123,6 +127,7 @@ particle_types:
       wires_profile: 
         branch: 'ph2Shower_wires_profile'
       matched_tps: []
+    filter: 'p.sl !=2' # only consider showers in SL1 and SL3 at the moment
   simhits:
     amount: 'simHit_nSimHits'
     attributes:

--- a/template_run_config.yaml
+++ b/template_run_config.yaml
@@ -82,12 +82,18 @@ particle_types:
         branch: 'ph2TpgPhiEmuAm_superLayer'
       phi: 
         branch: 'ph2TpgPhiEmuAm_phi'
+      phires_conv:
+        expr: '65536.0 / 0.5'
       phiB: 
         branch: 'ph2TpgPhiEmuAm_phiB'
+      phiBres_conv: 
+        expr: '4096.0 / 2.0'
       posLoc_x:
-        branch: 'ph2TpgPhiEmuAm_posLoc_x'
+        src: 'utils.tps_functions.compute_x0'
+        kwargs:
+          ref_frame: "SL13Center"
       dirLoc_phi:
-        branch: 'ph2TpgPhiEmuAm_dirLoc_phi'
+        src: 'utils.tps_functions.compute_psi_local'
       quality: 
         branch: 'ph2TpgPhiEmuAm_quality'
       rpcFlag: 
@@ -96,8 +102,6 @@ particle_types:
         branch: 'ph2TpgPhiEmuAm_BX'
       BX: # then re-define the BX attribute to center it at 0
         expr: '_BX - 20'
-      phires_conv:
-        expr: '65536.0 / 0.5'
       matched_segments: []
       matched_genmuons: []
       matched_showers: []
@@ -146,6 +150,7 @@ particle_types:
       wires_profile: 
         branch: 'ph2Shower_wires_profile'
       matched_tps: []
+    filter: 'p.sl !=2' # only consider showers in SL1 and SL3 at the moment
   simhits:
     amount: 'simHit_nSimHits'
     attributes:
@@ -290,6 +295,9 @@ plot_configs:
       src: "dtpr.utils.dt_plot_functions.embed_segs2axes_glob"  # Source of the artist
       rep-info:
         particle_type: 'tps'  # Particle type to use
+        pos_argname: 'posLoc_x'  # Attribute name to use for the position representation
+        angle_argname: 'dirLoc_phi'  # Attribute name to use for the angle representation
+        reference_frame: "SL13Center"  # Reference frame for the local coordinates, used in the src function to move posLoc_x and dirLoc_phi
         cmap_var: 'quality'   # Variable to use for the colormap
       segs_kwargs:
         linewidth: 0.8

--- a/utils/tps_functions.py
+++ b/utils/tps_functions.py
@@ -1,0 +1,66 @@
+from dtpr.base import Particle
+from mpldts.geometry import StationsCache
+import numpy as np
+
+Station = StationsCache().get 
+
+def compute_x0(tp: Particle, ref_frame="SL13Center") -> float:
+    """
+    Compute local position of the AM Trigger Primitive referenced to ref_frame. 
+    Base computation is done in the Sector Reference frame, where the x position can be computed as:
+
+        x0 = -1 * r_ch * tan(phi) * cos(Dphi) * parent_station.face_orientation_factor
+
+    where r_ch is the radial distance to the center of the chamber,
+    Dphi is the delta angle formed between the center of the station and the phi sector ray.
+    and parent_station.face_orientation_factor is -1 for (wh<0) or (wh==0 and sc in [1, 4, 5, 8, 9, 12, 13]) and 1 otherwise.
+
+    :param tp: The AM Trigger Primitive Particle instance.
+    :type tp: Particle
+    :param ref_frame: The reference frame to which the local x position should be computed. Available options are ["SL13Center" (default), "Station", "SectorRef"].
+    :type ref_frame: str
+    :return: The x position of the TP referenced to ref_frame.
+    :rtype: float
+    """
+    parent_station = Station(tp.wh, tp.sc, tp.st)
+
+    x_ch, y_ch, _ = parent_station.global_center
+
+    r_ch = np.sqrt(x_ch**2 + y_ch**2) # radial distance to the center of the chamber
+    phi_ch = np.arctan2(y_ch, x_ch) # angle of the chamber center in the CMS frame
+    sc = 4 if tp.sc == 13 else 10 if tp.sc == 14 else tp.sc # remap sc 13 and 14 to 4 and 10 for the dphi computation
+    dphi = phi_ch - (sc - 1) * np.pi / 6 # 30 degrees per sector
+
+    phi_rad = tp.phi / tp.phires_conv # convert phi to radians
+
+    # The x position in the Sector Reference frame is computed as:
+    x_0 = -1 * r_ch * np.tan(phi_rad) * np.cos(dphi) * parent_station.face_orientation_factor
+
+    if ref_frame != "SectorRef": # transform to the desired reference frame if needed
+        x_0 = parent_station.transformer.transform((x_0, 0, 0), from_frame="SectorRef", to_frame=ref_frame)[0]
+
+    return x_0
+
+def compute_psi_local(tp: Particle) -> float:
+    """
+    Compute the local angle of the AM Trigger Primitive referenced to ref_frame.
+    Base computation is done in the Sector Reference frame, where the local angle can be computed as:
+        psi_local = -1 * parent_station.face_orientation_factor * (phi + phiB)
+    
+    where phi and phiB are the angles get from the TP indicating: the position of the TP respect to the center of the phi sector, and the
+    bending angle of the TP respect to the phi angle ray respectivly. The parent_station.face_orientation_factor is -1 for (wh<0) or (wh==0 and sc in [1, 4, 5, 8, 9, 12, 13]) and 1 otherwise.
+    The -1 factor is consecuence of the fact that local station frames are inverted respect to the CMS frame (see https://intrepid-hep.github.io/mplDTs/src/patches/dt_station_patch.html).
+
+    :param tp: The AM Trigger Primitive Particle instance.
+    :type tp: Particle
+    :return: The local angle of the TP in degrees.
+    :rtype: float
+    """
+    parent_station = Station(tp.wh, tp.sc, tp.st)
+
+    phi_rad = tp.phi / tp.phires_conv # convert phi to radians
+    phiB_rad = tp.phiB / tp.phiBres_conv # convert phiB to radians
+
+    psi_local = -1 * parent_station.face_orientation_factor * (phi_rad + phiB_rad)
+
+    return np.degrees(psi_local)


### PR DESCRIPTION
As discussed in #2, using `phi` and `phiB` instead of local variables to represent the AM TP segments should be preferred, to avoid using variables that are not completely understood. However, due to the plotting package taking as base for the patches the local variables, it was still necessary to estimate the local vars instead of using the angles as suggested in #15. 

This PR includes the module to compute the local vars directly from `phi` and `phiB`, fixing the problem of badly drawn segments and then solving #15.

## Changes
- **New module**: `utils/tps_functions.py` with functions to compute TP local positions and angles
  - `compute_x0()`: Computes local x position from Sector_phi referenced to specified frame (SL13Center/Station/SectorRef)
     <img width="400" src="https://github.com/user-attachments/assets/31f9762b-6020-47b6-896c-de3e7de4ecdd" />
  - `compute_psi_local()`: Computes local angle from phi and phiB with correct orientation factors
     <img width="400" src="https://github.com/user-attachments/assets/77ccd565-5aaa-4ff7-8093-1e6945582d55" />
- **Config updates**: Updated run configuration templates
- Principal `config YAML` files where updated to include the changes.
- `filter_main.py` updated to use the changed variables and to use `StationsCache` class instead of a dictionary for manage the `Station` creation.

The changes were tested by visually plotting segments from a test sample using the [test_segments.py](https://github.com/user-attachments/files/25239684/test_segments.py) script, which produced figures such as the following:

<img width="600" src="https://github.com/user-attachments/assets/f8818586-21a0-4434-a6c5-337005af40c4" />
<img width="600" src="https://github.com/user-attachments/assets/a25c343b-e765-40a8-a309-592ef1e5bc6c" />
